### PR TITLE
New Features: Resynthesize Video and Frame Restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ App configuration is set via `config.yaml`
   - server address to use for Gradio http server
   - default is "0.0.0.0" which makes the app available on the local network as well
   - to prevent this, set to "127.0.0.1" or None
-- interpolate_settings\[gif_duration\]
+- interpolation_settings\[gif_duration\]
   - total time in ms for the animated GIF preview
   - default is 3000
 

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,10 @@ restoration_settings:
   max_frames: 10
   default_precision: 10
   max_precision: 60
+  gif_duration: 1000
+  create_gif: True
+  create_zip: True
+  create_txt: True
 user_interface:
   theme: "default"
   css_file: "webui.css"

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,8 @@ directories:
   output_interpolation: "./output/interpolation"
   output_inflation: "./output/inflation"
   output_search: "./output/search"
+  output_resynthesis: "./output/resynthesis"
+  output_restoration: "./output/restoration"
 model: "./pretrained_models/pretrained_VFIformer/net_220.pth"
 gpu_ids: "0"
 auto_launch_browser: True

--- a/config.yaml
+++ b/config.yaml
@@ -10,11 +10,19 @@ gpu_ids: "0"
 auto_launch_browser: True
 server_port: 7862
 server_name: "0.0.0.0"
-interpolate_settings:
+interpolation_settings:
+  max_splits: 10
   gif_duration: 3000
   create_gif: True
   create_zip: True
   create_txt: True
+search_settings:
+  max_splits: 60
+restoration_settings:
+  default_frames: 2
+  max_frames: 10
+  default_precision: 10
+  max_precision: 60
 user_interface:
   theme: "default"
   css_file: "webui.css"

--- a/interpolate_series.py
+++ b/interpolate_series.py
@@ -12,7 +12,8 @@ def main():
     parser.add_argument("--model", default="./pretrained_models/pretrained_VFIformer/net_220.pth", type=str)
     parser.add_argument("--gpu_ids", type=str, default="0", help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU")
     parser.add_argument("--input_path", default="./images", type=str, help="Input path for PNGs to interpolate")
-    parser.add_argument("--depth", default=2, type=int, help="how many doublings of the frames")
+    parser.add_argument("--depth", default=2, type=int, help="How many doublings of the frames")
+    parser.add_argument("--offset", default=1, type=int, help="Frame series offset, 1 for slow motion, 2+ for frame resynthesis")
     parser.add_argument("--output_path", default="./output", type=str, help="Output path for interpolated PNGs")
     parser.add_argument("--base_filename", default="interpolated_frames", type=str, help="Base filename for interpolated PNGs")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true", help="Show extra details")
@@ -26,7 +27,7 @@ def main():
     series_interpolater = InterpolateSeries(deep_interpolater, log.log)
 
     file_list = get_files(args.input_path, extension="png")
-    series_interpolater.interpolate_series(file_list, args.output_path, args.depth, args.base_filename)
+    series_interpolater.interpolate_series(file_list, args.output_path, args.depth, args.base_filename, args.offset)
 
 class InterpolateSeries():
     def __init__(self,
@@ -39,23 +40,32 @@ class InterpolateSeries():
         if self.log_fn:
             self.log_fn(message)
 
-    def interpolate_series(self, file_list : list, output_path : str, num_splits : int, base_filename : str):
+    def interpolate_series(self, file_list : list, output_path : str, num_splits : int, base_filename : str, offset : int = 1):
         file_list = sorted(file_list)
         count = len(file_list)
         num_width = len(str(count))
-
         pbar_desc = "Frames" if num_splits < 2 else "Total"
-        # stop short of beginning at the last frame since there's no frame after i
-        for n in tqdm(range(count-1), desc=pbar_desc, position=0):
+
+        for n in tqdm(range(count - offset), desc=pbar_desc, position=0):
             # for other than the first around, the duplicated real "before" frame is deleted for
             # continuity, since it's identical to the "after" from the previous round
             continued = n > 0
+
+            # if the offset is > 1 treat this as a resynthesis of frames
+            # and inform the deep interpolator to not keep the real frames
+            resynthesis = offset > 1
+
             before_file = file_list[n]
-            after_file = file_list[n+1]
-            filename = base_filename + "[" + str(n).zfill(num_width) + "]"
+            after_file = file_list[n + offset]
+
+            # if a resynthesis, start the file numbering at 1 to match the restored frame
+            # if an offset other than 2 is used, the frame numbers won't generally match
+            base_index = n + (1 if resynthesis else 0)
+            filename = base_filename + "[" + str(base_index).zfill(num_width) + "]"
+
             inner_bar_desc = f"Frame #{n}"
-            self.log("creating inflated frames files starting with " + filename)
-            self.deep_interpolater.split_frames(before_file, after_file, num_splits, output_path, filename, progress_label=inner_bar_desc, continued=continued)
+            self.log(f"creating inflated frames for frame files {before_file} - {after_file}")
+            self.deep_interpolater.split_frames(before_file, after_file, num_splits, output_path, filename, progress_label=inner_bar_desc, continued=continued, resynthesis=resynthesis)
 
 if __name__ == '__main__':
     main()

--- a/interpolate_series.py
+++ b/interpolate_series.py
@@ -27,12 +27,17 @@ def main():
 
     file_list = get_files(args.input_path, extension="png")
     series_interpolater.interpolate_series(file_list, args.output_path, args.depth, args.base_filename)
-    
+
 class InterpolateSeries():
-    def __init__(self, 
+    def __init__(self,
                 deep_interpolater : DeepInterpolate,
                 log_fn : Callable | None):
         self.deep_interpolater = deep_interpolater
+        self.log_fn = log_fn
+
+    def log(self, message):
+        if self.log_fn:
+            self.log_fn(message)
 
     def interpolate_series(self, file_list : list, output_path : str, num_splits : int, base_filename : str):
         file_list = sorted(file_list)
@@ -42,13 +47,14 @@ class InterpolateSeries():
         pbar_desc = "Frames" if num_splits < 2 else "Total"
         # stop short of beginning at the last frame since there's no frame after i
         for n in tqdm(range(count-1), desc=pbar_desc, position=0):
-            # for other than the first around, the duplicated real "before" frame is deleted for 
+            # for other than the first around, the duplicated real "before" frame is deleted for
             # continuity, since it's identical to the "after" from the previous round
             continued = n > 0
             before_file = file_list[n]
             after_file = file_list[n+1]
             filename = base_filename + "[" + str(n).zfill(num_width) + "]"
-            inner_bar_desc = f"Frame #{n}" 
+            inner_bar_desc = f"Frame #{n}"
+            self.log("creating inflated frames files starting with " + filename)
             self.deep_interpolater.split_frames(before_file, after_file, num_splits, output_path, filename, progress_label=inner_bar_desc, continued=continued)
 
 if __name__ == '__main__':

--- a/interpolation_target.py
+++ b/interpolation_target.py
@@ -1,14 +1,14 @@
 import os
-import cv2
 import argparse
+from typing import Callable
+import re
+import cv2
 from tqdm import tqdm
 from interpolate_engine import InterpolateEngine
 from interpolate import Interpolate
 from webui_utils.simple_log import SimpleLog
-from webui_utils.simple_utils import max_steps, float_range_in_range
+from webui_utils.simple_utils import float_range_in_range
 from webui_utils.file_utils import create_directory
-from typing import Callable
-import re
 
 def main():
     parser = argparse.ArgumentParser(description="Video Frame Interpolation to a specify time")
@@ -32,7 +32,7 @@ def main():
     target_interpolater.split_frames(args.img_before, args.img_after, args.depth, args.min_target, args.max_target, args.output_path, args.base_filename)
 
 class TargetInterpolate():
-    def __init__(self, 
+    def __init__(self,
                 interpolater : Interpolate,
                 log_fn : Callable | None):
         self.interpolater = interpolater
@@ -47,13 +47,13 @@ class TargetInterpolate():
             self.log_fn(message)
 
     def split_frames(self,
-                    before_filepath : str, 
-                    after_filepath : str, 
-                    num_splits : int, 
+                    before_filepath : str,
+                    after_filepath : str,
+                    num_splits : int,
                     min_target : float,
                     max_target : float,
-                    output_path : str, 
-                    base_filename : str, 
+                    output_path : str,
+                    base_filename : str,
                     progress_label="Split"):
         self.init_frame_register()
         self.reset_split_manager(num_splits)
@@ -63,12 +63,12 @@ class TargetInterpolate():
         self.set_up_outer_frames(before_filepath, after_filepath, output_filepath_prefix)
 
         self.recursive_split_frames(0.0, 1.0, output_filepath_prefix, min_target, max_target)
-        self.isolate_target_frame(output_path, base_filename)
+        self.isolate_target_frame()
         self.close_progress()
 
     def recursive_split_frames(self,
-                                first_index : float, 
-                                last_index : float, 
+                                first_index : float,
+                                last_index : float,
                                 filepath_prefix : str,
                                 min_target : float,
                                 max_target : float):
@@ -95,9 +95,9 @@ class TargetInterpolate():
                     self.log(f"skipping, unable to locate target {min_target},{max_target} within split ranges {first_index},{mid_index} and {mid_index},{last_index}")
             self.exit_split()
 
-    def set_up_outer_frames(self, 
-                            before_file, 
-                            after_file, 
+    def set_up_outer_frames(self,
+                            before_file,
+                            after_file,
                             output_filepath_prefix):
         img0 = cv2.imread(before_file)
         img1 = cv2.imread(after_file)
@@ -115,11 +115,18 @@ class TargetInterpolate():
         self.register_frame(after_file)
         self.log("copied " + after_file)
 
-    def isolate_target_frame(self, output_path, base_name):
+    def isolate_target_frame(self):
         frame_files = self.registered_frames()
 
         # the kept frame will be the last frame registered
         kept_file = frame_files.pop(-1)
+
+        # duplicates of the kept file may have been created, ensure they're not present
+        frame_files = [file for file in frame_files if file != kept_file]
+
+        # remove other duplicates
+        frame_files = list(set(frame_files))
+
         filepath, fvalue, ext = self.split_indexed_filepath(kept_file)
         new_kept_file = f"{filepath}@{fvalue}{ext}"
         os.replace(kept_file, new_kept_file)
@@ -168,7 +175,7 @@ class TargetInterpolate():
 
     # filepath prefix representing the split position while splitting
     def indexed_filepath(self, filepath_prefix, index):
-        return filepath_prefix + f"{index:1.24f}.png"
+        return filepath_prefix + f"{index:1.55f}.png"
 
     def split_indexed_filepath(self, filepath : str):
         regex = r"(.+)([1|0]\..+)(\..+$)"

--- a/resequence_files.py
+++ b/resequence_files.py
@@ -19,24 +19,24 @@ def main():
     args = parser.parse_args()
 
     log = SimpleLog(args.verbose)
-    ResequenceFiles(args.path, 
-                    args.file_type, 
-                    args.new_name, 
-                    args.start, 
-                    args.step, 
-                    args.zero_fill, 
-                    args.rename, 
+    ResequenceFiles(args.path,
+                    args.file_type,
+                    args.new_name,
+                    args.start,
+                    args.step,
+                    args.zero_fill,
+                    args.rename,
                     log.log).resequence()
 
 class ResequenceFiles:
-    def __init__(self, 
+    def __init__(self,
                 path : str,
-                file_type : str, 
-                new_base_filename : str, 
-                start_index : int, 
-                index_step : int, 
+                file_type : str,
+                new_base_filename : str,
+                start_index : int,
+                index_step : int,
                 zero_fill : int,
-                rename : bool , 
+                rename : bool ,
                 log_fn : Callable | None):
         self.path = path
         self.file_type = file_type
@@ -54,7 +54,7 @@ class ResequenceFiles:
 
         max_file_num = num_files * self.index_step
         num_width = len(str(max_file_num)) if self.zero_fill < 0 else self.zero_fill
-        index = 0
+        index = self.start_index
         pbar_title = "Renaming" if self.rename else "Copying"
 
         for file in tqdm(files, desc=pbar_title):

--- a/restore_frames.py
+++ b/restore_frames.py
@@ -1,0 +1,58 @@
+import argparse
+from typing import Callable
+from tqdm import tqdm
+from interpolate_engine import InterpolateEngine
+from interpolate import Interpolate
+from interpolation_target import TargetInterpolate
+from webui_utils.simple_log import SimpleLog
+from webui_utils.file_utils import create_directory
+from webui_utils.simple_utils import restored_frame_searches
+
+def main():
+    parser = argparse.ArgumentParser(description="Video Frame Interpolation (deep)")
+    parser.add_argument("--model", default="./pretrained_models/pretrained_VFIformer/net_220.pth", type=str)
+    parser.add_argument("--gpu_ids", type=str, default="0", help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU")
+    parser.add_argument("--img_before", default="./images/image0.png", type=str, help="Path to image file before the damaged frames")
+    parser.add_argument("--img_after", default="./images/image2.png", type=str, help="Path to image file after the damaged frames")
+    parser.add_argument("--num_frames", default=2, type=int, help="Number of frames to restore")
+    parser.add_argument("--depth", default=10, type=int, help="How deep the frame splits go to reach the target")
+    parser.add_argument("--output_path", default="./output", type=str, help="Output path for interpolated PNGs")
+    parser.add_argument("--base_filename", default="restored_frame", type=str, help="Base filename for interpolated PNGs")
+    parser.add_argument("--verbose", dest="verbose", default=False, action="store_true", help="Show extra details")
+    args = parser.parse_args()
+
+    log = SimpleLog(args.verbose)
+    create_directory(args.output_path)
+    engine = InterpolateEngine(args.model, args.gpu_ids)
+    interpolater = Interpolate(engine.model, log.log)
+    target_interpolater = TargetInterpolate(interpolater, log.log)
+    frame_restorer = RestoreFrames(target_interpolater, log.log)
+
+    frame_restorer.restore_frames(args.img_before, args.img_after, args.num_frames, args.depth, args.output_path, args.base_filename)
+
+class RestoreFrames():
+    def __init__(self,
+                target_interpolater : TargetInterpolate,
+                log_fn : Callable | None):
+        self.target_interpolater = target_interpolater
+        self.log_fn = log_fn
+
+    def log(self, message):
+        if self.log_fn:
+            self.log_fn(message)
+
+    def restore_frames(self, img_before : str, img_after : str, num_frames : int, depth: int, output_path : str, base_filename : str):
+        searches = restored_frame_searches(num_frames)
+        for search in tqdm(searches, desc="Frames"):
+            self.log(f"searching for frame {search}")
+            self.target_interpolater.split_frames(img_before,
+                                                img_after,
+                                                depth,
+                                                min_target=search,
+                                                max_target=search,
+                                                output_path=output_path,
+                                                base_filename=base_filename,
+                                                progress_label="Search")
+
+if __name__ == '__main__':
+    main()

--- a/restore_frames.py
+++ b/restore_frames.py
@@ -36,6 +36,7 @@ class RestoreFrames():
                 log_fn : Callable | None):
         self.target_interpolater = target_interpolater
         self.log_fn = log_fn
+        self.output_paths = []
 
     def log(self, message):
         if self.log_fn:
@@ -53,6 +54,7 @@ class RestoreFrames():
                                                 output_path=output_path,
                                                 base_filename=base_filename,
                                                 progress_label="Search")
+        self.output_paths.extend(self.target_interpolater.output_paths)
 
 if __name__ == '__main__':
     main()

--- a/webui.py
+++ b/webui.py
@@ -15,6 +15,7 @@ from webui_utils.file_utils import create_directories, create_zip, get_files, cr
 from webui_utils.simple_utils import max_steps, restored_frame_fractions, restored_frame_predictions
 from resequence_files import ResequenceFiles
 from interpolation_target import TargetInterpolate
+from restore_frames import RestoreFrames
 
 log = None
 config = None
@@ -162,7 +163,42 @@ def resequence_files(input_path : str, input_filetype : str, input_newname : str
         ResequenceFiles(input_path, input_filetype, input_newname, int(input_start), int(input_step), int(input_zerofill), input_rename_check, log.log).resequence()
 
 def frame_restoration(img_before_file : str, img_after_file : str, num_frames : float, num_splits : float):
-    return #gr.Image.update(value=preview_gif), gr.File.update(value=downloads, visible=True)
+    global log, config, engine, file_output
+    if img_before_file and img_after_file:
+        interpolater = Interpolate(engine.model, log.log)
+        target_interpolater = TargetInterpolate(interpolater, log.log)
+        frame_restorer = RestoreFrames(target_interpolater, log.log)
+        base_output_path = config.directories["output_restoration"]
+        create_directory(base_output_path)
+        output_path, run_index = AutoIncrementDirectory(base_output_path).next_directory("run")
+        output_basename = "restored_frame"
+
+        log.log(f"beginning frame restorations at {output_path}")
+        frame_restorer.restore_frames(img_before_file, img_after_file, num_frames, num_splits, output_path, output_basename)
+        output_paths = frame_restorer.output_paths
+
+        downloads = []
+        preview_gif = None
+        if config.restoration_settings["create_gif"]:
+            preview_gif = os.path.join(output_path, output_basename + str(run_index) + ".gif")
+            log.log(f"creating preview file {preview_gif}")
+            duration = config.restoration_settings["gif_duration"] / len(output_paths)
+            gif_paths = [img_before_file, *output_paths, img_after_file]
+            create_gif(gif_paths, preview_gif, duration=duration)
+            downloads.append(preview_gif)
+
+        if config.restoration_settings["create_zip"]:
+            download_zip = os.path.join(output_path, output_basename + str(run_index) + ".zip")
+            log.log("creating zip of frame files")
+            create_zip(output_paths, download_zip)
+            downloads.append(download_zip)
+
+        if config.restoration_settings["create_txt"]:
+            info_file = os.path.join(output_path, output_basename + str(run_index) + ".txt")
+            create_report(info_file, img_before_file, img_after_file, num_splits, output_path, output_paths)
+            downloads.append(info_file)
+
+        return gr.Image.update(value=preview_gif), gr.File.update(value=downloads, visible=True)
 
 def restart_app():
     global restart
@@ -249,21 +285,22 @@ def create_ui():
             resynthesize_button_rv = gr.Button("Resynthesize Video (this will take time)", variant="primary")
 
         with gr.Tab("Frame Restoration"):
-            gr.HTML("Restore two or more adjacent restored frames using Frame Search and download the restored frames", elem_id="tabheading")
+            gr.HTML("Restore two or more adjacent restored frames using Frame Search and download the download the frames", elem_id="tabheading")
             with gr.Row(variant="compact"):
                 with gr.Column(variant="panel"):
                     with gr.Row(variant="compact"):
-                        img1_input_fr = gr.Image(type="filepath", label="Frame before first restored one", tool=None, shape=(192, 108))
-                        img2_input_fr = gr.Image(type="filepath", label="Frame after last restored one", tool=None, shape=(192, 108))
+                        img1_input_fr = gr.Image(type="filepath", label="Frame before replacement frames", tool=None)
+                        img2_input_fr = gr.Image(type="filepath", label="Frame after replacement frames", tool=None)
                     with gr.Row(variant="compact"):
                         frames_input_fr = gr.Slider(value=config.restoration_settings["default_frames"], minimum=1, maximum=config.restoration_settings["max_frames"], step=1, label="Frames to restore")
                         precision_input_fr = gr.Slider(value=config.restoration_settings["default_precision"], minimum=1, maximum=config.restoration_settings["max_precision"], step=1, label="Search Precision")
+                    with gr.Row(variant="compact"):
+                        times_default = restored_frame_fractions(config.restoration_settings["default_frames"])
+                        times_output_fr = gr.Textbox(value=times_default, label="Frame Search Times", max_lines=1, interactive=False)
                 with gr.Column(variant="panel"):
                     img_output_fr = gr.Image(type="filepath", label="Animated Preview", interactive=False)
                     file_output_fr = gr.File(type="file", file_count="multiple", label="Download", visible=False)
-            times_default = restored_frame_fractions(config.restoration_settings["default_frames"])
             predictions_default = restored_frame_predictions(config.restoration_settings["default_frames"], config.restoration_settings["default_precision"])
-            times_output_fr = gr.Textbox(value=times_default, label="Frame Search Times", max_lines=1, interactive=False)
             predictions_output_fr = gr.Textbox(value=predictions_default, label="Predicted matches", max_lines=1, interactive=False)
             restore_button_fr = gr.Button("Restore Frames", variant="primary")
 

--- a/webui.py
+++ b/webui.py
@@ -144,18 +144,19 @@ def video_inflation(input_path : str, output_path : str | None, num_splits : flo
 def resynthesize_video(input_path : str, output_path : str | None):
     global log, config, engine, file_output
     if input_path:
-        # interpolater = Interpolate(engine.model, log.log)
-        # deep_interpolater = DeepInterpolate(interpolater, log.log)
-        # series_interpolater = InterpolateSeries(deep_interpolater, log.log)
-        # base_output_path = output_path or config.directories["output_inflation"]
-        # create_directory(base_output_path)
-        # output_path, run_index = AutoIncrementDirectory(base_output_path).next_directory("run")
-        # output_basename = "interpolated_frames"
-        # file_list = get_files(input_path, extension="png")
+        interpolater = Interpolate(engine.model, log.log)
+        deep_interpolater = DeepInterpolate(interpolater, log.log)
+        series_interpolater = InterpolateSeries(deep_interpolater, log.log)
+        base_output_path = output_path or config.directories["output_resynthesis"]
+        create_directory(base_output_path)
+        output_path, run_index = AutoIncrementDirectory(base_output_path).next_directory("run")
+        output_basename = "resynthesized_frames"
 
-        # log.log(f"beginning series of deep interpolations at {output_path}")
-        # series_interpolater.interpolate_series(file_list, output_path, num_splits, output_basename)
-        log.log(f"awaiting implementation")
+        file_list = get_files(input_path, extension="png")
+        log.log(f"beginning series of frame recreations at {output_path}")
+        series_interpolater.interpolate_series(file_list, output_path, 1, output_basename, offset=2)
+        log.log(f"auto-resequencing recreated frames at {output_path}")
+        ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, -1, True, log.log).resequence()
 
 def resequence_files(input_path : str, input_filetype : str, input_newname : str, input_start : str, input_step : str, input_zerofill : str, input_rename_check : bool):
     global log
@@ -276,12 +277,12 @@ def create_ui():
             interpolate_button_vi = gr.Button("Interpolate Series (this will take time)", variant="primary")
 
         with gr.Tab("Resynthesize Video"):
-            gr.HTML("Interpolate all-new frames from a video for use in restoration restored frames", elem_id="tabheading")
+            gr.HTML("Interpolate replacement frames from an entire video for use in video restoration", elem_id="tabheading")
             with gr.Row(variant="compact"):
                 with gr.Column(variant="panel"):
                     input_path_text_rv = gr.Text(max_lines=1, placeholder="Path on this server to the frame PNG files", label="Input Path")
                     output_path_text_rv = gr.Text(max_lines=1, placeholder="Where to place the generated frames, leave blank to use default", label="Output Path")
-            gr.Markdown("*Progress can be tracked in the console*")
+            gr.Markdown("Note the first and last frames cannot be resynthesized. *Progress can be tracked in the console*")
             resynthesize_button_rv = gr.Button("Resynthesize Video (this will take time)", variant="primary")
 
         with gr.Tab("Frame Restoration"):

--- a/webui.py
+++ b/webui.py
@@ -140,6 +140,22 @@ def video_inflation(input_path : str, output_path : str | None, num_splits : flo
         log.log(f"beginning series of deep interpolations at {output_path}")
         series_interpolater.interpolate_series(file_list, output_path, num_splits, output_basename)
 
+def resynthesize_video(input_path : str, output_path : str | None):
+    global log, config, engine, file_output
+    if input_path:
+        # interpolater = Interpolate(engine.model, log.log)
+        # deep_interpolater = DeepInterpolate(interpolater, log.log)
+        # series_interpolater = InterpolateSeries(deep_interpolater, log.log)
+        # base_output_path = output_path or config.directories["output_inflation"]
+        # create_directory(base_output_path)
+        # output_path, run_index = AutoIncrementDirectory(base_output_path).next_directory("run")
+        # output_basename = "interpolated_frames"
+        # file_list = get_files(input_path, extension="png")
+
+        # log.log(f"beginning series of deep interpolations at {output_path}")
+        # series_interpolater.interpolate_series(file_list, output_path, num_splits, output_basename)
+        log.log(f"awaiting implementation")
+
 def resequence_files(input_path : str, input_filetype : str, input_newname : str, input_start : str, input_step : str, input_zerofill : str, input_rename_check : bool):
     global log
     if input_path and input_filetype and input_newname and input_start and input_step and input_zerofill:
@@ -209,6 +225,37 @@ def create_ui():
                         info_output_vi = gr.Textbox(value="1", label="Interpolations per Frame", max_lines=1, interactive=False)
             gr.Markdown("*Progress can be tracked in the console*")
             interpolate_button_vi = gr.Button("Interpolate Series (this will take time)", variant="primary")
+        with gr.Tab("Resynthesize Video"):
+            gr.HTML("Interpolate all-new frames from a video for use in restoration", elem_id="tabheading")
+            with gr.Row(variant="compact"):
+                with gr.Column(variant="panel"):
+                    input_path_text_rv = gr.Text(max_lines=1, placeholder="Path on this server to the frame PNG files", label="Input Path")
+                    output_path_text_rv = gr.Text(max_lines=1, placeholder="Where to place the generated frames, leave blank to use default", label="Output Path")
+            gr.Markdown("*Progress can be tracked in the console*")
+            resynthesize_button_rv = gr.Button("Resynthesize Video (this will take time)", variant="primary")
+        with gr.Tab("Frame Restoration"):
+            gr.HTML("Restore two or more adjacent damaged frames using Frame Search and download the restored frames", elem_id="tabheading")
+            with gr.Row(variant="compact"):
+                with gr.Column(variant="panel"):
+                    img1_input_fr = gr.Image(type="filepath", label="Frame before first damaged one", tool=None)
+                    img2_input_fr = gr.Image(type="filepath", label="Frame after last damaged one", tool=None)
+                    with gr.Row(variant="compact"):
+                        frames_input_fr = gr.Slider(value=2, minimum=1, maximum=10, step=1, label="Frames to repair")
+                        precision_input_fr = gr.Slider(value=1, minimum=1, maximum=10, step=1, label="Precision")
+                        info_output_fr = gr.Textbox(value="1", label="Interpolated Frames", max_lines=1, interactive=False)
+                with gr.Column(variant="panel"):
+                    img_output_fi = gr.Image(type="filepath", label="Animated Preview", interactive=False)
+                    file_output_fi = gr.File(type="file", file_count="multiple", label="Download", visible=False)
+            interpolate_button_fi = gr.Button("Interpolate", variant="primary")
+
+
+
+            # with gr.Row(variant="compact"):
+            #     with gr.Column(variant="panel"):
+            #         input_path_text_rv = gr.Text(max_lines=1, placeholder="Path on this server to the frame PNG files", label="Input Path")
+            #         output_path_text_rv = gr.Text(max_lines=1, placeholder="Where to place the generated frames, leave blank to use default", label="Output Path")
+            # gr.Markdown("*Progress can be tracked in the console*")
+            # resynthesize_button_rv = gr.Button("Resynthesize Video (this will take time)", variant="primary")
         with gr.Tab("Tools"):
             with gr.Row(variant="compact"):
                 restart_button = gr.Button("Restart App", variant="primary").style(full_width=False)
@@ -254,6 +301,8 @@ def create_ui():
 
         interpolate_button_vi.click(video_inflation, inputs=[input_path_text_vi, output_path_text_vi, splits_input_vi])
         splits_input_vi.change(update_splits_info, inputs=splits_input_vi, outputs=info_output_vi, show_progress=False)
+
+        resynthesize_button_rv.click(resynthesize_video, inputs=[input_path_text_rv, output_path_text_rv])
 
         restart_button.click(restart_app, _js="setTimeout(function(){location.reload()},1000)")
 

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -34,23 +34,20 @@ def predict_search_frame(num_splits : int, fractional_time : float) -> float:
     resolution = 2 ** num_splits
     return round(resolution * fractional_time) / resolution
 
-# For Frame Restoration, given a count of damaged frames
+# For Frame Restoration, given a count of restored frames
+# compute the frame search times for the new frames that will be created
+def restored_frame_searches(restored_frame_count : int) -> list:
+    return [(n + 1.0) / (restored_frame_count + 1.0) for n in range(restored_frame_count)]
+
+# For Frame Restoration, given a count of restored frames
 # compute a human friendly display of the fractional
 # times for the new frames that will be created
-def damaged_frame_fractions(damaged_frame_count : int) -> str:
-    return ", ".join([f"{n + 1}/{damaged_frame_count + 1}" for n in range(damaged_frame_count)])
+def restored_frame_fractions(restored_frame_count : int) -> str:
+    return ", ".join([f"{n + 1}/{restored_frame_count + 1}" for n in range(restored_frame_count)])
 
-# For Frame Restoration, given a count of damaged frames
-# compute the frame search times for the new frames that will be created
-def damaged_frame_searches(damaged_frame_count : int) -> list:
-    return [(n + 1.0) / (damaged_frame_count + 1.0) for n in range(damaged_frame_count)]
-
-# For Frame Restoration, given a count of damaged frames
+# For Frame Restoration, given a count of restored frames
 # and a precision (split count) compute the frames that
 # are likely to be found given that precision
-def damaged_frame_predictions(damaged_frame_count : int, num_splits : int) -> list:
-    searches = damaged_frame_searches(damaged_frame_count)
-    return [predict_search_frame(num_splits, search) for search in searches]
-
-
-
+def restored_frame_predictions(restored_frame_count : int, num_splits : int) -> list:
+    searches = restored_frame_searches(restored_frame_count)
+    return ", ".join([str(predict_search_frame(num_splits, search)) for search in searches])

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -45,9 +45,19 @@ def restored_frame_searches(restored_frame_count : int) -> list:
 def restored_frame_fractions(restored_frame_count : int) -> str:
     return ", ".join([f"{n + 1}/{restored_frame_count + 1}" for n in range(restored_frame_count)])
 
+WARNING_SYM = "⚠️"
+
 # For Frame Restoration, given a count of restored frames
 # and a precision (split count) compute the frames that
 # are likely to be found given that precision
 def restored_frame_predictions(restored_frame_count : int, num_splits : int) -> list:
     searches = restored_frame_searches(restored_frame_count)
-    return ", ".join([str(predict_search_frame(num_splits, search)) for search in searches])
+    predictions = [str(predict_search_frame(num_splits, search)) for search in searches]
+
+    # prepare to detect duplicates, including the outer frames
+    all_frames = predictions + ["0.0"] + ["1.0"]
+
+    warning = ""
+    if len(set(all_frames)) != len(all_frames):
+        warning = f" {WARNING_SYM} Repeated frames - increase precision"
+    return ", ".join(predictions) + warning

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -26,3 +26,31 @@ def float_range_in_range(target_min : float, target_max : float, domain_min : fl
         else:
             return False
 
+
+# For Frame Search, given a frame time 0.0 - 1.0
+# and a search depth (split count) compute the fractional
+# time that will actually be found
+def predict_search_frame(num_splits : int, fractional_time : float) -> float:
+    resolution = 2 ** num_splits
+    return round(resolution * fractional_time) / resolution
+
+# For Frame Restoration, given a count of damaged frames
+# compute a human friendly display of the fractional
+# times for the new frames that will be created
+def damaged_frame_fractions(damaged_frame_count : int) -> str:
+    return ", ".join([f"{n + 1}/{damaged_frame_count + 1}" for n in range(damaged_frame_count)])
+
+# For Frame Restoration, given a count of damaged frames
+# compute the frame search times for the new frames that will be created
+def damaged_frame_searches(damaged_frame_count : int) -> list:
+    return [(n + 1.0) / (damaged_frame_count + 1.0) for n in range(damaged_frame_count)]
+
+# For Frame Restoration, given a count of damaged frames
+# and a precision (split count) compute the frames that
+# are likely to be found given that precision
+def damaged_frame_predictions(damaged_frame_count : int, num_splits : int) -> list:
+    searches = damaged_frame_searches(damaged_frame_count)
+    return [predict_search_frame(num_splits, search) for search in searches]
+
+
+


### PR DESCRIPTION
Resynthesize Video - create a set of replacement frames for an entire movie to use in film restoration
- point to a directory of video frame PNG files
- it interpolates all new _odd_ frames between the even ones, and all new _even_ frames between the odd ones for a complete set of replacements (the first and last frame cannot be resynthesized)
- the output files are named for the the frame they replace
- they can be used to restore a film by selectively replacing bad frames with the synthesized ones

Frame Restoration - create replacement frames for two or more _adjacent_ damaged / unusable frames using Frame Search
- provide _good_ frames _before_ and _after_ the damaged ones
- tell it how many frames are damaged
- uses frame search to find closest match replacement frames at precise times
- search precision can be set very high for accuracy
