### PR TITLE
make the auto video preview more robust

### DIFF
--- a/video_blender_projects.csv
+++ b/video_blender_projects.csv
@@ -1,1 +1,2 @@
 project_name,project_path,frames1_path,frames2_path
+"Untitled",,,

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -1,22 +1,23 @@
 import os
+import glob
 from ffmpy import FFmpeg, FFprobe
 
 # ffprobe -v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames -print_format default=nokey=1:noprint_wrappers=1 Big_Buck_Bunny_1080_10s_20MB.mp4
-
 def MP4_frame_count(input_path : str) -> int:
     ff = FFprobe(inputs= {input_path : "-count_frames -show_entries stream=nb_read_frames -print_format default=nokey=1:noprint_wrappers=1"})
     return ff.run()
 
-# ffmpeg -i BALLOON%03d.png -c:v libx264 -r 30 -pix_fmt yuv420p frames.mp4
 
 QUALITY_NEAR_LOSSLESS = 17
 QUALITY_SMALLER_SIZE = 28
 QUALITY_DEFAULT = 23
 
-# if filename_pattern is "auto" it uses the filename of the first found file and the count of file to determine it
+# ffmpeg -i BALLOON%03d.png -c:v libx264 -r 30 -pix_fmt yuv420p frames.mp4
+# if filename_pattern is "auto" it uses the filename of the first found file
+# and the count of file to determine the pattern, .png as the file type
 def PNGtoMP4(input_path : str, filename_pattern : str, frame_rate : int, output_filepath : str, crf : int = 23):
     if filename_pattern == "auto":
-        files = sorted(os.listdir(input_path))
+        files = sorted(glob.glob(os.path.join(input_path, "*.png")))
         first_file = files[0]
         file_count = len(files)
         num_width = len(str(file_count))
@@ -30,7 +31,6 @@ def PNGtoMP4(input_path : str, filename_pattern : str, frame_rate : int, output_
     return cmd
 
 # ffmpeg -y -i frames.mp4 -filter:v fps=25 -pix_fmt rgba -start_number 0 output_%09d.png
-
 def MP4toPNG(input_path : str, filename_pattern : str, frame_rate : int, output_path : str, start_number : int = 0):
     ff = FFmpeg(inputs= {input_path : None},
                 outputs={os.path.join(output_path, filename_pattern) : f"-filter:v fps={frame_rate} -pix_fmt rgba -start_number {start_number}"},


### PR DESCRIPTION
- ignore non .png files if using the "auto" filename pattern for PNGtoMP4