### PR TITLE
GIF to MP4 works as MP4 to MP4 just as well

### DIFF
--- a/tabs/gif_to_mp4_ui.py
+++ b/tabs/gif_to_mp4_ui.py
@@ -45,16 +45,16 @@ class GIFtoMP4():
             with gr.Row():
                 with gr.Column():
                     with gr.Row():
-                        input_path_text = gr.Text(max_lines=1, label="GIF File",
-                            placeholder="Path on this server to the GIF file to be converted")
+                        input_path_text = gr.Text(max_lines=1, label="GIF File (MP4 works too)",
+                            placeholder="Path on this server to the GIF or MP4 file to be converted")
                     with gr.Row():
                         upscale_input = gr.Slider(value=4.0, minimum=1.0, maximum=8.0, step=0.05,
                             label="GIF Frame Size Upscale Factor")
                         inflation_input = gr.Slider(value=4.0, minimum=1.0, maximum=8.0, step=1.0,
                             label="GIF Frame Rate Upscale Factor")
-                        order_input = gr.Radio(value="Size first then Rate",
-                            choices=["Size first then Rate", "Rate first then size"],
-                            label="Processing Order")
+                        order_input = gr.Radio(value="Rate, then Size (may be faster)",
+                            choices=["Rate, then Size (faster)", "Size, then Rate (may be smoother)"],
+                            label="Frame Processing Order")
                     with gr.Row():
                         output_path_text = gr.Text(max_lines=1, label="MP4 File",
                             placeholder="Path on this server for the converted MP4 file")
@@ -84,7 +84,7 @@ class GIFtoMP4():
             working_path, run_index = AutoIncrementDirectory(
                 self.config.directories["output_gif_to_mp4"]).next_directory("run")
             precision = self.config.gif_to_mp4_settings["resampling_precision"]
-            size_first = True if order == "Size first then Rate" else False
+            size_first = True if order[0] == "S" else False
 
             frames_path = os.path.join(working_path, "gif_to_png")
             create_directory(frames_path)

--- a/tabs/gif_to_mp4_ui.py
+++ b/tabs/gif_to_mp4_ui.py
@@ -53,7 +53,7 @@ class GIFtoMP4():
                         inflation_input = gr.Slider(value=4.0, minimum=1.0, maximum=8.0, step=1.0,
                             label="GIF Frame Rate Upscale Factor")
                         order_input = gr.Radio(value="Rate, then Size (may be faster)",
-                            choices=["Rate, then Size (faster)", "Size, then Rate (may be smoother)"],
+                            choices=["Rate, then Size (may be faster)", "Size, then Rate (may be smoother)"],
                             label="Frame Processing Order")
                     with gr.Row():
                         output_path_text = gr.Text(max_lines=1, label="MP4 File",


### PR DESCRIPTION
FFmpeg will happily take whatever you give it and make a set of PNG files, so remove the restriction on this working for GIF only
- tested with animated GIFs and MP4 files
- there's no restriction on the input filetype, so something like `.mpeg` ought to work
- with GIF and MP4 there's automatic frame count detection
- with any other format it presumes a high count of 100K to ensure the frame filenames are alpha-sortable

Can be used for:
- recovering original video from animated GIFs and low FPS MP4 files
- recovering original video from timelapse videos
- creating slow-motion videos in one-click