### PR TITLE
Upscaling fix

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -59,6 +59,7 @@ upscale_settings:
   - "png"
   - "jpg"
   - "gif"
+  - "bmp"
 logviewer_settings:
   max_lines: 25
 user_interface:

--- a/guide/upscale_frames.md
+++ b/guide/upscale_frames.md
@@ -3,7 +3,7 @@
 ## Uses
 - Increase the size of video frames
 - Clean up dirty/deteriorated frames
-- Use without upscaling to clean frames
+- Can be used to clean frames without upscaling
 
 ## Important
 Real-ESRGAN must be installed locally to use
@@ -14,13 +14,15 @@ Real-ESRGAN must be installed locally to use
 
 ## How It Works
 1. Set _Input Path_ to a directory on this server to the PNG files to be upscaled
+    - JPG, GIF and BMP files will also be upscaled if found in the path
+    - _Tip: the config setting_ `upscale_settings:file_types` _specifies the searched types_
 1. Set _Output Path_ to a directory on this server for the upscaled PNG files
-    - Output Path can be left blank to use the default folder
-    - The default folder is set by the `config.directories.output_upscaling` setting
+    - If Output Path is set, upscaled files are saved as sequentially indexed PNG files with a fixed filename
+    - When Output Path is left empty, upscaled files are saved to the input path using the original filename and format, and marked with the outscale amount.
 1. Set _Frame Upscale Factor_ for the desired amount of frame enlargement
     - The factor can be set between 1.0 and 8.0 in 0.05 steps
-    - Real-ESRGAN does upscaling if the factor if > 1.0
-        - It also removes dirt and noise even if not upscaling
+    - Real-ESRGAN will perform upscaling when _factor_ is > 1.0
+        - _Tip: It will remove dirt and noise even when not upscaling_
 1. Click _Upscale Frames_
 1. _Real-ESRGAN_ is used on each frame in the input path
     - Frames are cleaned up, and enlarged if necessary

--- a/tabs/gif_to_mp4_ui.py
+++ b/tabs/gif_to_mp4_ui.py
@@ -132,7 +132,7 @@ class GIFtoMP4(TabBase):
         upscaler = UpscaleSeries(model_name, gpu_ips, fp32, self.log)
         output_basename = "upscaled_frames"
         file_list = get_files(input_path, extension="png")
-        upscaler.upscale_series(file_list, output_path, upscale_factor, output_basename)
+        upscaler.upscale_series(file_list, output_path, upscale_factor, output_basename, "png")
 
     def inflate_using_noop(self,
                             input_path : str,

--- a/tabs/upscale_frames_ui.py
+++ b/tabs/upscale_frames_ui.py
@@ -26,10 +26,10 @@ class UpscaleFrames(TabBase):
             with gr.Row():
                 with gr.Column():
                     input_path_text = gr.Text(max_lines=1,
-        placeholder="Path on this server to the frame PNG files (also upscales JPG and GIF files)",
+    placeholder="Path on this server to the frame PNG files (also upscales JPG, GIF, BMP files)",
                         label="Input Path")
                     output_path_text = gr.Text(max_lines=1,
-                placeholder="Where to place the upscaled frames, leave blank to use default path",
+                placeholder="Where to place the upscaled frames, leave blank save to input path",
                         label="Output Path")
                     with gr.Row():
                         scale_input = gr.Slider(value=4.0, minimum=1.0, maximum=8.0, step=0.05,
@@ -47,13 +47,18 @@ class UpscaleFrames(TabBase):
             gpu_ips = self.config.gpu_ids
             fp32 = self.config.realesrgan_settings["fp32"]
             upscaler = UpscaleSeries(model_name, gpu_ips, fp32, self.log)
+
             if output_path:
                 create_directory(output_path)
+                output_basename = "upscaled_frames"
+                output_type = "png"
             else:
-                base_output_path = self.config.directories["output_upscaling"]
-                output_path, _ = AutoIncrementDirectory(base_output_path).next_directory("run")
-            output_basename = "upscaled_frames"
+                output_path = input_path
+                output_basename = None
+                output_type = None
+
             image_extensions = self.config.upscale_settings["file_types"]
             file_list = get_files(input_path, image_extensions)
             self.log(f"beginning series of upscaling of {image_extensions} files at {output_path}")
-            upscaler.upscale_series(file_list, output_path, upscale_factor, output_basename)
+            upscaler.upscale_series(file_list, output_path, upscale_factor, output_basename,
+                                    output_type)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+import os
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+print(ROOT_DIR)

--- a/test.py
+++ b/test.py
@@ -1,3 +1,0 @@
-import os
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-print(ROOT_DIR)

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -39,16 +39,19 @@ def _get_types(extension : str | list | None) -> list:
 
 def get_files(path : str, extension : list | str | None=None) -> list:
     """Get a list of files in the path per the extension(s)"""
-    if isinstance(extension, (list, str, type(None))):
-        files = []
-        extensions, bad_extensions = _get_types(extension)
-        if bad_extensions:
-            raise ValueError("extension list items must be a strings")
-        for ext in extensions:
-            files += _get_files(os.path.join(path, "*." + ext))
-        return files #list(set(files))
+    if isinstance(path, str):
+        if isinstance(extension, (list, str, type(None))):
+            files = []
+            extensions, bad_extensions = _get_types(extension)
+            if bad_extensions:
+                raise ValueError("extension list items must be a strings")
+            for ext in extensions:
+                files += _get_files(os.path.join(path, "*." + ext))
+            return list(set(files))
+        else:
+            raise ValueError("'extension' must be a string, a list of strings, or 'None'")
     else:
-        raise ValueError("'extension' must be a string, a list of strings, or 'None'")
+        raise ValueError("'path' must be a string")
 
 def get_directories(path : str) -> list:
     """Get a list of directories in the path"""

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -82,3 +82,68 @@ def split_filepath(filepath : str):
         return path, filename, ext
     else:
         raise ValueError("'filepath' must be a string")
+
+def build_filename(base_file_ext : str | None, file_part : str | None, ext_part : str | None):
+    """Build a new filename from a base with optional replacements for name and type"""
+    if isinstance(base_file_ext, (str, type(None))):
+        if base_file_ext:
+            base_file, base_ext = os.path.splitext(base_file_ext)
+        else:
+            base_file, base_ext = "", ""
+    else:
+        raise ValueError("'base_file_ext' must be a string or None")
+    if isinstance(file_part, (str, type(None))):
+        if file_part != None:
+            filename = file_part
+        else:
+            filename = base_file
+    else:
+        raise ValueError("'file_part' must be a string or None")
+    if isinstance(ext_part, (str, type(None))):
+        if ext_part != None:
+            extension = ext_part
+        else:
+            extension = base_ext
+    else:
+        raise ValueError("'ext_part' must be a string or None")
+    extension = extension.strip(".")
+    if extension:
+        extension = "." + extension
+    return f"{filename}{extension}" #if filename and extension else ""
+
+# extension can be None if it is included with the filename argument
+def build_indexed_filename(filename : str, extension : str | None, index : int | float, max_index : int | float):
+    """Build a new filename including an integer index from a base filename + extension"""
+    if not isinstance(filename, str):
+        raise ValueError("'filename' must be a string")
+    if isinstance(extension, (str, type(None))):
+        if extension == None:
+            filename, extension = os.path.splitext(filename)
+        extension = extension.strip(".")
+        if extension:
+            extension = "." + extension
+    else:
+        raise ValueError("'extension' must be a string or None")
+    if isinstance(index, (int, float)):
+        index = int(index)
+        if index < 0:
+            raise ValueError("'index' value must be >= 0")
+    else:
+        raise ValueError("'index' must be an int or float")
+    if isinstance(max_index, (int, float)):
+        max_index = int(max_index)
+        if max_index < 1:
+            raise ValueError("'max_index' value must be >= 1")
+        if max_index < index:
+            raise ValueError("'max_index' value must be >= 'index'")
+    else:
+        raise ValueError("'max_index' must be an int or float")
+    num_width = len(str(max_index))
+    return f"{filename}{str(index).zfill(num_width)}{extension}"
+
+def build_series_filename(base_filename : str | None, output_type : str | None, index : int | float, max_index : int | float, input_filename : str | None):
+    """Build an output filename for a series operation, given a base filename, output type,
+       index, index range and optional overriding original filename"""
+    if base_filename:
+        base_filename = build_indexed_filename(base_filename, None, index, max_index)
+    return build_filename(input_filename, base_filename, output_type)

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -21,16 +21,32 @@ def _get_files(path : str):
             files.append(entry)
     return files
 
-def get_files(path : str, extension : list | str | None=None) -> list:
-    """Get a list of files in the path per the extension"""
-    if isinstance(extension, (str, type(None))):
-        extension = "*" if extension == None else extension
-        return _get_files(os.path.join(path, "*." + extension))
+def _get_types(extension : str | list | None) -> list:
+    extensions = []
+    if isinstance(extension, type(None)):
+        extensions.append("*")
+    elif isinstance(extension, str):
+        extensions += extension.split(",")
     elif isinstance(extension, list):
+        extensions += extension
+    result, unused = [], []
+    for ext in extensions:
+        if isinstance(ext, str):
+            result.append(ext.strip(" ."))
+        else:
+            unused.append(ext)
+    return list(set(result)), unused
+
+def get_files(path : str, extension : list | str | None=None) -> list:
+    """Get a list of files in the path per the extension(s)"""
+    if isinstance(extension, (list, str, type(None))):
         files = []
-        for ext in extension:
+        extensions, bad_extensions = _get_types(extension)
+        if bad_extensions:
+            raise ValueError("extension list items must be a strings")
+        for ext in extensions:
             files += _get_files(os.path.join(path, "*." + ext))
-        return files
+        return files #list(set(files))
     else:
         raise ValueError("'extension' must be a string, a list of strings, or 'None'")
 

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -76,6 +76,9 @@ def locate_frame_file(png_files_path : str, frame_number : int):
 
 def split_filepath(filepath : str):
     """Split a filepath into path, filename, extension"""
-    path, filename = os.path.split(filepath)
-    filename, ext = os.path.splitext(filename)
-    return path, filename, ext
+    if isinstance(filepath, str):
+        path, filename = os.path.split(filepath)
+        filename, ext = os.path.splitext(filename)
+        return path, filename, ext
+    else:
+        raise ValueError("'filepath' must be a string")

--- a/webui_utils/test_file_utils.py
+++ b/webui_utils/test_file_utils.py
@@ -1,0 +1,11 @@
+import pytest
+from . import file_utils
+
+TEST_ASSETS_DIR = "./test_assets"
+BAD_EXTENSION_ARGS = [1, 2.0, {3:3}]
+
+def test_get_files():
+
+    for bad_extension_arg in BAD_EXTENSION_ARGS:
+        with pytest.raises(ValueError, match="'extension' must be a string, a list of strings, or 'None'"):
+            file_utils.get_files(TEST_ASSETS_DIR, bad_extension_arg)

--- a/webui_utils/test_file_utils.py
+++ b/webui_utils/test_file_utils.py
@@ -45,3 +45,27 @@ def test_get_files(capsys):
         nondupe_result = file_utils.get_files(FIXTURE_PATH, nondupe)
         dupe_result = file_utils.get_files(FIXTURE_PATH, dupe)
         assert len(dupe_result) == len(nondupe_result)
+
+GOOD_PATH_SPLITS = [
+    ("path1/path2/filename.extension", ("path1/path2", "filename", ".extension")),
+    ("/filename.extension", ("/", "filename", ".extension")),
+    ("/filename", ("/", "filename", "")),
+    ("filename", ("", "filename", "")),
+    (".filename", ("", ".filename", "")),
+    (".", ("", ".", "")),
+    ("", ("", "", ""))]
+
+BAD_PATH_SPLITS = [
+    (None, (None, None, None)),
+    (1, (None, None, None)),
+    (2.0, (None, None, None)),
+    ({3:3}, (None, None, None)),
+    ([4], (None, None, None))]
+
+def test_split_filepath():
+    for split_str, split_list in BAD_PATH_SPLITS:
+        with pytest.raises(ValueError, match="'filepath' must be a string"):
+            file_utils.split_filepath(split_str) == split_list
+
+    for split_str, split_list in GOOD_PATH_SPLITS:
+        assert file_utils.split_filepath(split_str) == split_list

--- a/webui_utils/test_file_utils.py
+++ b/webui_utils/test_file_utils.py
@@ -1,11 +1,47 @@
+import os
 import pytest
 from . import file_utils
 
-TEST_ASSETS_DIR = "./test_assets"
+FIXTURE_PATH = "./images"
+FIXTURE_EXTENSION = "png"
+FIXTURE_FILES = [os.path.join(FIXTURE_PATH, file) for file in
+                 ["image0.png", "image1.png", "image2.png", "screenshot.png"]]
+
+BAD_PATH_ARGS = [None, 1, 2.0, {3:3}, [4]]
+GOOD_PATH_ARGS = [FIXTURE_PATH]
 BAD_EXTENSION_ARGS = [1, 2.0, {3:3}]
+GOOD_EXTENSION_ARGS = [FIXTURE_EXTENSION, None, "*", ".png", "png,gif", "png, gif", ".png,.gif",
+                        ["gif", "png"], [".gif", ".png"]]
+DUPLICATE_EXTENSION_ARGS = [("png", "png,png"), ("png", "png,.png"), ("*", "*,*"), ("*", "*,png")]
 
-def test_get_files():
+def test_get_files(capsys):
+    # with capsys.disabled():
+    #     print(os.path.abspath(FIXTURE_PATH))
 
-    for bad_extension_arg in BAD_EXTENSION_ARGS:
+    for bad_arg in BAD_PATH_ARGS:
+        with pytest.raises(ValueError, match="'path' must be a string"):
+            file_utils.get_files(bad_arg, FIXTURE_EXTENSION)
+
+    for bad_arg in BAD_EXTENSION_ARGS:
         with pytest.raises(ValueError, match="'extension' must be a string, a list of strings, or 'None'"):
-            file_utils.get_files(TEST_ASSETS_DIR, bad_extension_arg)
+            file_utils.get_files(FIXTURE_PATH, bad_arg)
+
+    # good paths should return real results
+    for good_arg in GOOD_PATH_ARGS:
+        result = file_utils.get_files(good_arg, FIXTURE_EXTENSION)
+        assert len(result) > 0
+
+    # excess whitespace and dots should be ignored
+    for good_arg in GOOD_EXTENSION_ARGS:
+        result = file_utils.get_files(FIXTURE_PATH, good_arg)
+        assert len(result) > 0
+
+    # should get a predicted set of files including the prepended path
+    result = file_utils.get_files(FIXTURE_PATH, FIXTURE_EXTENSION)
+    assert set(result) == set(FIXTURE_FILES)
+
+    # should not get overlapping results
+    for nondupe, dupe in DUPLICATE_EXTENSION_ARGS:
+        nondupe_result = file_utils.get_files(FIXTURE_PATH, nondupe)
+        dupe_result = file_utils.get_files(FIXTURE_PATH, dupe)
+        assert len(dupe_result) == len(nondupe_result)

--- a/webui_utils/test_file_utils.py
+++ b/webui_utils/test_file_utils.py
@@ -69,3 +69,139 @@ def test_split_filepath():
 
     for split_str, split_list in GOOD_PATH_SPLITS:
         assert file_utils.split_filepath(split_str) == split_list
+
+GOOD_BUILD_FILENAME_ARGS = [
+    (("filename1.ext", None, None), "filename1.ext"),
+    (("filename2.ext", "", ""), ""),
+    ((None, "somefile1", "txt"), "somefile1.txt"),
+    (("", "somefile2", "txt"), "somefile2.txt"),
+    ((None, None, None), ""),
+    (("", "", ""), ""),
+    (("filename1.ext", None, ".txt"), "filename1.txt"),
+    (("filename2.ext", None, "txt"), "filename2.txt"),
+    (("filename.ext", "somefile3", None), "somefile3.ext"),
+    (("filename4.ext", "", ".txt"), ".txt"),
+    (("filename5.ext", "", "txt"), ".txt"),
+    (("filename.ext", "somefile4", ""), "somefile4"),
+    (("filename.ext", "somefile5", "txt"), "somefile5.txt"),
+    (("filename.ext", None, ""), "filename"),
+    (("filename.ext", "", None), ".ext")]
+
+BAD_BUILD_FILENAME_ARGS = [
+    ((1, 1, 1), "'base_file_ext' must be a string or None"),
+    ((2.0, 2.0, 2.0), "'base_file_ext' must be a string or None"),
+    (({3:3}, {3:3}, {3:3}), "'base_file_ext' must be a string or None"),
+    (([4], [4], [4]), "'base_file_ext' must be a string or None"),
+    (("", 1, 1), "'file_part' must be a string or None"),
+    (("", 2.0, 2.0), "'file_part' must be a string or None"),
+    (("", {3:3}, {3:3}), "'file_part' must be a string or None"),
+    (("", [4], [4]), "'file_part' must be a string or None"),
+    ((None, 1, 1), "'file_part' must be a string or None"),
+    ((None, 2.0, 2.0), "'file_part' must be a string or None"),
+    ((None, {3:3}, {3:3}), "'file_part' must be a string or None"),
+    ((None, [4], [4]), "'file_part' must be a string or None"),
+    (("", "", 1), "'ext_part' must be a string or None"),
+    (("", "", 2.0), "'ext_part' must be a string or None"),
+    (("", "", {3:3}), "'ext_part' must be a string or None"),
+    (("", "", [4]), "'ext_part' must be a string or None"),
+    ((None, None, 1), "'ext_part' must be a string or None"),
+    ((None, None, 2.0), "'ext_part' must be a string or None"),
+    ((None, None, {3:3}), "'ext_part' must be a string or None"),
+    ((None, None, [4]), "'ext_part' must be a string or None")]
+
+def test_build_filename():
+    for good_args, result in GOOD_BUILD_FILENAME_ARGS:
+        assert result == file_utils.build_filename(*good_args)
+
+    for bad_args, match_text in BAD_BUILD_FILENAME_ARGS:
+        with pytest.raises(ValueError, match=match_text):
+            file_utils.build_filename(*bad_args)
+
+GOOD_BUILD_INDEXED_FILENAME_ARGS = [
+    (("filename1", "ext", 1, 100), "filename1001.ext"),
+    (("filename2.ext", None, 1, 100), "filename2001.ext"),
+    (("filename3", "ext", 12345, 99999), "filename312345.ext"),
+    (("filename4", "ext", 0, 100), "filename4000.ext"),
+    (("", "ext", 1, 100), "001.ext"),
+    (("filename5", None, 1, 100), "filename5001"),
+    (("filename6", "", 1, 100), "filename6001")]
+
+BAD_BUILD_INDEXED_FILENAME_ARGS = [
+    ((None, "ext", 1, 100), "'filename' must be a string"),
+    ((1, "ext", 1, 100), "'filename' must be a string"),
+    ((2.0, "ext", 1, 100), "'filename' must be a string"),
+    (({3:3}, "ext", 1, 100), "'filename' must be a string"),
+    (([4], "ext", 1, 100), "'filename' must be a string"),
+    (("", 1, 1, 100), "'extension' must be a string"),
+    (("", 2.0, 1, 100), "'extension' must be a string"),
+    (("", {3:3}, 1, 100), "'extension' must be a string"),
+    (("", [4], 1, 100), "'extension' must be a string"),
+    (("", "", None, 100), "'index' must be an int or float"),
+    (("", "", "", 100), "'index' must be an int or float"),
+    (("", "", {3:3}, 100), "'index' must be an int or float"),
+    (("", "", [4], 100), "'index' must be an int or float"),
+    (("", "", 0, None), "'max_index' must be an int or float"),
+    (("", "", 0, ""), "'max_index' must be an int or float"),
+    (("", "", 0, {3:3}), "'max_index' must be an int or float"),
+    (("", "", 0, [4]), "'max_index' must be an int or float"),
+    (("", "", -1, 100), "'index' value must be >= 0"),
+    (("", "", -2.0, 100), "'index' value must be >= 0"),
+    (("", "", 0, -1), "'max_index' value must be >= 1"),
+    (("", "", 0, -2.0), "'max_index' value must be >= 1"),
+    (("", "", 100, 90), "'max_index' value must be >= 'index'")]
+
+def test_build_indexed_filename():
+    for good_args, result in GOOD_BUILD_INDEXED_FILENAME_ARGS:
+        assert result == file_utils.build_indexed_filename(*good_args)
+
+    for bad_args, match_text in BAD_BUILD_INDEXED_FILENAME_ARGS:
+        with pytest.raises(ValueError, match=match_text):
+            file_utils.build_indexed_filename(*bad_args)
+
+GOOD_BUILD_SERIES_FILENAME_ARGS = [
+    (("pngsequence", "png", 1, 10, None), "pngsequence01.png"),
+    (("pngsequence", ".png", 2, 100, None), "pngsequence002.png"),
+    (("pngsequence", "gif", 10, 1000, "somefile.txt"), "pngsequence0010.gif"),
+    (("pngsequence00", "png", 1, 10, None), "pngsequence0001.png"),
+    (("pngsequence", None, 1, 9, "somefile.txt"), "pngsequence1.txt"),
+    ((None, "jpg", 0, 9, "somefile.txt"), "somefile.jpg"),
+    ((None, None, 0, 1, "somefile.txt"), "somefile.txt"),
+    (("pngsequence", "png", 2.0, 10, None), "pngsequence02.png"),
+    (("pngsequence", "png", 3, 333.0, None), "pngsequence003.png"),
+    (("pngsequence", "png", 4.0, 4444.0, None), "pngsequence0004.png"),
+    ((None, None, 0, 1, "somefile"), "somefile"),
+    ((None, "png", 0, 1, "somefile"), "somefile.png"),
+    ((None, None, 0, 1, ".ext"), ".ext"),
+    ((None, None, 0, 1, ""), ""),
+    ((None, None, 0, 1, None), ""),
+    (("somefile", None, 0, 1, ".ext"), "somefile0"),
+    (("somefile", None, 0, 1, "other.ext"), "somefile0.ext"),
+    ((None, None, 0, 0, None), ""),
+]
+
+BAD_BUILD_SERIES_FILENAME_ARGS = [
+    (("pngsequence", None, 0, 0, None), "'max_index' value must be >= 1"),
+    (("pngsequence", None, -1, 0, None), "'index' value must be >= 0"),
+    (("pngsequence", None, 0, -1, None), "'max_index' value must be >= 1"),
+    (("pngsequence", None, 2, 1, None), "'max_index' value must be >= 'index'"),
+    ((1, None, 0, 0, None), "'filename' must be a string"),
+    ((2.0, None, 0, 0, None), "'filename' must be a string"),
+    (({3:3}, None, 0, 0, None), "'filename' must be a string"),
+    (([4], None, 0, 0, None), "'filename' must be a string"),
+    (("", 1, 0, 0, None), "'ext_part' must be a string or None"),
+    (("", 2.0, 0, 0, None), "'ext_part' must be a string or None"),
+    (("", {3:3}, 0, 0, None), "'ext_part' must be a string or None"),
+    (("", [4], 0, 0, None), "'ext_part' must be a string or None"),
+    (("", "", 0, 0, 1), "'base_file_ext' must be a string or None"),
+    (("", "", 0, 0, 2.0), "'base_file_ext' must be a string or None"),
+    (("", "", 0, 0, {3:3}), "'base_file_ext' must be a string or None"),
+    (("", "", 0, 0, [4]), "'base_file_ext' must be a string or None"),
+]
+
+def test_build_series_filename():
+    for good_args, result in GOOD_BUILD_SERIES_FILENAME_ARGS:
+        assert result == file_utils.build_series_filename(*good_args)
+
+    for bad_args, match_text in BAD_BUILD_SERIES_FILENAME_ARGS:
+        with pytest.raises(ValueError, match=match_text):
+            file_utils.build_series_filename(*bad_args)

--- a/webui_utils/test_file_utils.py
+++ b/webui_utils/test_file_utils.py
@@ -1,5 +1,5 @@
 import os
-import pytest
+import pytest # pylint: disable=import-error
 from . import file_utils
 
 FIXTURE_PATH = "./images"


### PR DESCRIPTION
Make it easier to use the upscaling feature with sets of arbitrary image files
- the output path can be left blank
- in this case the upscaled image is saved back to the input path with the same filename and type, and and added marker for the outscale amount

Also
- have begun adding Pytest tests, starting with core filename utilities