### PR TITLE
Add tiling option for R-ESRGAN

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,6 +51,7 @@ fps_change_settings:
   max_precision: 60
 gif_to_mp4_settings:
   resampling_precision: 10
+  use_tiling: False
 realesrgan_settings:
   model_name: "RealESRGAN_x4plus"
   fp32: True

--- a/config.yaml
+++ b/config.yaml
@@ -54,10 +54,13 @@ gif_to_mp4_settings:
 realesrgan_settings:
   model_name: "RealESRGAN_x4plus"
   fp32: True
+  tiling: 256
+  tile_pad: 10
 upscale_settings:
   file_types:
   - "png"
   - "jpg"
+  - "jpeg"
   - "gif"
   - "bmp"
 logviewer_settings:

--- a/guide/upscale_frames.md
+++ b/guide/upscale_frames.md
@@ -23,6 +23,13 @@ Real-ESRGAN must be installed locally to use
     - The factor can be set between 1.0 and 8.0 in 0.05 steps
     - Real-ESRGAN will perform upscaling when _factor_ is > 1.0
         - _Tip: It will remove dirt and noise even when not upscaling_
+1. Choose whether or not to use _Tiling_
+    - Select _No_ for the best quality.
+        - Entire images will be upscaled at once
+    - Select _Yes_ if upscaling large images, or running into low VRAM conditions
+        - Images will be upscaled in blocks then stiched together
+        - Tiling _Size_ and _Padding_ (in pixels) are set using the config settings:
+            - `realesrgan_settings:tiling` and `realesrgan_settings:tile_pad`
 1. Click _Upscale Frames_
 1. _Real-ESRGAN_ is used on each frame in the input path
     - Frames are cleaned up, and enlarged if necessary

--- a/tabs/gif_to_mp4_ui.py
+++ b/tabs/gif_to_mp4_ui.py
@@ -129,7 +129,13 @@ class GIFtoMP4(TabBase):
         model_name = self.config.realesrgan_settings["model_name"]
         gpu_ips = self.config.gpu_ids
         fp32 = self.config.realesrgan_settings["fp32"]
-        upscaler = UpscaleSeries(model_name, gpu_ips, fp32, self.log)
+        if self.config.gif_to_mp4_settings["use_tiling"]:
+            tiling = self.config.realesrgan_settings["tiling"]
+            tile_pad = self.config.realesrgan_settings["tile_pad"]
+        else:
+            tiling = 0
+            tile_pad = 0
+        upscaler = UpscaleSeries(model_name, gpu_ips, fp32, tiling, tile_pad, self.log)
         output_basename = "upscaled_frames"
         file_list = get_files(input_path, extension="png")
         upscaler.upscale_series(file_list, output_path, upscale_factor, output_basename, "png")

--- a/tabs/upscale_frames_ui.py
+++ b/tabs/upscale_frames_ui.py
@@ -34,19 +34,26 @@ class UpscaleFrames(TabBase):
                     with gr.Row():
                         scale_input = gr.Slider(value=4.0, minimum=1.0, maximum=8.0, step=0.05,
                             label="Frame Upscale Factor")
+                        use_tiling = gr.Radio(label="Use Tiling", choices=["No (Best Quality)", "Yes (If Low VRAM)"], value="No (Best Quality)")
             upscale_button = gr.Button("Upscale Frames", variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.upscale_frames.render()
         upscale_button.click(self.upscale_frames,
-            inputs=[input_path_text, output_path_text, scale_input])
+            inputs=[input_path_text, output_path_text, scale_input, use_tiling])
 
-    def upscale_frames(self, input_path : str, output_path : str | None, upscale_factor : float):
+    def upscale_frames(self, input_path : str, output_path : str | None, upscale_factor : float, use_tiling : str):
         """Upscale Frames button handler"""
         if input_path:
             model_name = self.config.realesrgan_settings["model_name"]
             gpu_ips = self.config.gpu_ids
             fp32 = self.config.realesrgan_settings["fp32"]
-            upscaler = UpscaleSeries(model_name, gpu_ips, fp32, self.log)
+            if use_tiling[0] == "Y":
+                tiling = self.config.realesrgan_settings["tiling"]
+                tile_pad = self.config.realesrgan_settings["tile_pad"]
+            else:
+                tiling = 0
+                tile_pad = 0
+            upscaler = UpscaleSeries(model_name, gpu_ips, fp32, tiling, tile_pad, self.log)
 
             if output_path:
                 create_directory(output_path)


### PR DESCRIPTION
Add support for the tiling feature of Real-ESRGAN to handle large images or low VRAM conditions.
- With tiling enabled, images are processed in 256x256 blocks that are stitched into the final image
- Padding is used to conceal seams
- The tiling block and padding sizes are settable in `config.yaml`